### PR TITLE
Update docker-client.sh to untar to /tmp

### DIFF
--- a/docker-client.sh
+++ b/docker-client.sh
@@ -10,10 +10,10 @@ echo -e "\e[34m»»» 📦 \e[32mInstalling \e[33m$NAME \e[35mv$VERSION\e[0m ...
 
 mkdir -p $INSTALL_DIR
 curl -sSL https://download.docker.com/linux/static/stable/x86_64/docker-$VERSION.tgz -o /tmp/docker.tgz
-tar -zxvf /tmp/docker.tgz docker/docker
-chmod +x docker/docker
-mv docker/docker $INSTALL_DIR/docker
-rmdir docker/
+tar -zxvf /tmp/docker.tgz -C /tmp docker/docker
+chmod +x /tmp/docker/docker
+mv /tmp/docker/docker $INSTALL_DIR/docker
+rmdir /tmp/docker/
 rm -rf /tmp/docker.tgz
 
 echo -e "\n\e[34m»»» 💾 \e[32mInstalled to: \e[33m$(which $CMD)"


### PR DESCRIPTION
I hit issues with this script in `docker build` if the WORKDIR hadn't been set. This PR forces the tar output to `/tmp`