### PR TITLE
Derailed/k9s changed the download assets names on latest K9s release.

### DIFF
--- a/k9s.sh
+++ b/k9s.sh
@@ -11,7 +11,7 @@ INSTALL_DIR=${2:-"$HOME/.local/bin"}
 CMD=k9s
 NAME="k9s"
 
-curl -sL "https://github.com/derailed/k9s/releases/download/v$VERSION/k9s_Linux_x86_64.tar.gz" -o /tmp/k9s.tar.gz
+curl -sL "https://github.com/derailed/k9s/releases/download/v${VERSION}/k9s_v${VERSION}_Linux_x86_64.tar.gz" -o /tmp/k9s.tar.gz
 tar -xf /tmp/k9s.tar.gz -C /tmp k9s
 mkdir -p $INSTALL_DIR
 sudo mv /tmp/k9s $INSTALL_DIR


### PR DESCRIPTION
Hi @benc-uk 

Derailed/k9s changed the names of the assets for the first time.
The fix will update the download URI.

![image](https://user-images.githubusercontent.com/116467/119472340-7306ff00-bd4a-11eb-9b81-cc02afe36989.png)

Thanks
Bart
